### PR TITLE
Reference upper package from demo app

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -26,7 +26,7 @@
     "react-draggable": "^4.5.0",
     "react-hook-form": "^7.68.0",
     "react-transition-group": "^4.4.5",
-    "zarr-cesium": "0.1.4",
+    "zarr-cesium": "file:..",
     "zod": "^4.1.13"
   },
   "devDependencies": {


### PR DESCRIPTION
Small change to reference the main repo package while running the demo (and not using a released version)